### PR TITLE
Make columnist() accept a sequence of columns

### DIFF
--- a/sources/library.dylan
+++ b/sources/library.dylan
@@ -60,6 +60,7 @@ define module columnist-protocol
       $border-header,
       $border-bottom,
     <alignment>,
+    display-table,
     display-header,
     display-data-row,
     display-border-row,


### PR DESCRIPTION
Most of the time there's no need to instantiate a <columnist> object; just pass a sequence of columns and maybe `borders: b` directly to `columnist()`.

Export `display-table` from columnist-protocol.